### PR TITLE
Adding export to class so it can be used from C++ code.

### DIFF
--- a/Source/eXiSoundVis/Public/SoundVisComponent.h
+++ b/Source/eXiSoundVis/Public/SoundVisComponent.h
@@ -40,7 +40,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FWorkerFinished, USoundWave*, SoundW
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FFrequencySpectrumCalculated, const TArray<float>&, OutFrequencies);
 
 UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent), meta=(DisplayName = "SoundVisComponent") )
-class USoundVisComponent : public UActorComponent
+class EXISOUNDVIS_API USoundVisComponent : public UActorComponent
 {
 	GENERATED_BODY()
 


### PR DESCRIPTION
Hey,

Your code could only be used from blueprints, but I'm doing most my work from C++ code.

This simple change allows the plugin to be used from other C++ classes/code.