### PR TITLE
Fixing missing comma in plugin file that was causing editor loading i…

### DIFF
--- a/eXiSoundVis.uplugin
+++ b/eXiSoundVis.uplugin
@@ -11,7 +11,7 @@
 	[
 		{
 			"Name" : "eXiSoundVis",
-			"Type" : "Runtime"
+			"Type" : "Runtime",
 			"LoadingPhase" : "PreDefault"
 		}
 	]


### PR DESCRIPTION
Quick fix for a missing comma in the .uplugin file that was causing editor startup errors.